### PR TITLE
check if player is a NPC

### DIFF
--- a/src/main/java/net/zerotoil/dev/cyberlevels/listeners/EXPListeners.java
+++ b/src/main/java/net/zerotoil/dev/cyberlevels/listeners/EXPListeners.java
@@ -97,6 +97,13 @@ public class EXPListeners implements Listener {
     private void onPlayerDeath(PlayerDeathEvent event) {
         if (event.getEntity().getLastDamageCause() == null) return;
         Player player = event.getEntity();
+
+        // check if is NPC
+        boolean isCitizensNPC = player.hasMetadata("NPC"); 
+        if (isCitizensNPC) {
+            return;
+        }
+
         sendPermissionExp(player, main.expCache().expEarnEvents().get("dying"));
     }
 


### PR DESCRIPTION
Check if player is a NPC on `onPlayerDeath` to prevent error:

```
java.lang.NullPointerException: Cannot invoke "net.zerotoil.dev.cyberlevels.objects.levels.PlayerData.removeExp(double)" because the return value of "java.util.Map.get(Object)" is null
        at CyberLevels-0.5.9.jar/net.zerotoil.dev.cyberlevels.listeners.EXPListeners.sendPermissionExp(EXPListeners.java:333) ~[CyberLevels-0.5.9.jar:?]
        at CyberLevels-0.5.9.jar/net.zerotoil.dev.cyberlevels.listeners.EXPListeners.onPlayerDeath(EXPListeners.java:100) ~[CyberLevels-0.5.9.jar:?]
        at com.destroystokyo.paper.event.executor.MethodHandleEventExecutor.execute(MethodHandleEventExecutor.java:40) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:1.20.6-2233-0d6766e]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:628) ~[purpur-api-1.20.6-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerDeathEvent(CraftEventFactory.java:1029) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.level.ServerPlayer.die(ServerPlayer.java:1065) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.nms.v1_20_R4.entity.EntityHumanNPC.die(EntityHumanNPC.java:116) ~[Citizens-2.0.36-b3633.jar:?]
        at net.minecraft.world.entity.LivingEntity.hurt(LivingEntity.java:1631) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.world.entity.player.Player.hurt(Player.java:1025) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.level.ServerPlayer.hurt(ServerPlayer.java:1243) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.nms.v1_20_R4.entity.EntityHumanNPC.hurt(EntityHumanNPC.java:255) ~[Citizens-2.0.36-b3633.jar:?]
        at net.minecraft.world.entity.LivingEntity.onBelowWorld(LivingEntity.java:2640) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.world.entity.Entity.checkBelowWorld(Entity.java:975) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.world.entity.Entity.baseTick(Entity.java:955) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.world.entity.LivingEntity.baseTick(LivingEntity.java:425) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.nms.v1_20_R4.entity.EntityHumanNPC.doTick(EntityHumanNPC.java:129) ~[Citizens-2.0.36-b3633.jar:?]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.nms.v1_20_R4.util.NMSImpl.lambda$playerTicker$3(NMSImpl.java:1351) ~[Citizens-2.0.36-b3633.jar:?]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.util.PlayerUpdateTask$PlayerTick.run(PlayerUpdateTask.java:86) ~[Citizens-2.0.36-b3633.jar:?]
        at Citizens-2.0.36-b3633.jar/net.citizensnpcs.util.PlayerUpdateTask.run(PlayerUpdateTask.java:71) ~[Citizens-2.0.36-b3633.jar:?]
        at org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:101) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:482) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1734) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:503) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1606) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1260) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:326) ~[purpur-1.20.6.jar:1.20.6-2233-0d6766e]
        at java.base/java.lang.Thread.run(Thread.java:1570) ~[?:?]
```